### PR TITLE
Add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,3 +364,23 @@ def handle_error(code, context, debug, config) -> None: ...
 * **Maintainer:** Eric (default) across all agents for now.
 
 ---
+
+## Cursor Cloud specific instructions
+
+### Quick reference
+
+| Action | Command |
+|--------|---------|
+| Install deps | `uv sync` |
+| Lint | `ruff check .` |
+| Tests | `uv run pytest` |
+| Build | `uv build` |
+| Run pipeline on an image | `uv run python3 -c "import numpy, PIL.Image; from resistor_reader.orchestrator import read_resistor, load_config; print(read_resistor(numpy.asarray(PIL.Image.open('resistor_pictures/0000.jpg')), load_config('tests/test.yaml')))"` |
+
+### Notes
+
+- **uv** must be on `PATH`. It is installed to `~/.local/bin` by the setup script. If missing: `curl -LsSf https://astral.sh/uv/install.sh | sh` and add `~/.local/bin` to `PATH`.
+- **ruff** is installed as a uv tool (`uv tool install ruff`), not as a project dependency. Run it directly via `ruff check .` (not `uv run ruff`).
+- The `main.py` entry point (`python3 resistor_reader/main.py read`) requires Raspberry Pi hardware (GPIO, PiCamera2, I2C display). On dev machines, test the CV pipeline via `orchestrator.read_resistor()` or `uv run pytest`.
+- Many `test_orchestrator.py` parametrized cases are expected to fail — the pipeline is under active development and AGENTS.md states tests should never be deleted even if implementation doesn't yet support them.
+- Golden test images live in `resistor_pictures/` with ground truth in `resistor_pictures/resistors.csv`. Additional ROI test crops are in `tests/data/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with:

- Quick-reference table for common dev commands (`uv sync`, `ruff check .`, `uv run pytest`, `uv build`)
- Notes on `uv` and `ruff` tooling setup (uv installed via install script, ruff as a uv tool)
- Clarification that `main.py` requires Raspberry Pi hardware — use `orchestrator.read_resistor()` or `pytest` for dev testing
- Note about expected `test_orchestrator.py` failures (pipeline under active development, tests intentionally kept)
- Golden test data locations (`resistor_pictures/`, `tests/data/`)

### Environment verification

Pipeline demo output:
[pipeline_demo.log](https://cursor.com/agents/bc-607958b7-8924-48c9-a5a2-37bbe608c272/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpipeline_demo.log)

Test summary (72 passed, 88 expected failures):
[test_summary.log](https://cursor.com/agents/bc-607958b7-8924-48c9-a5a2-37bbe608c272/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_summary.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-607958b7-8924-48c9-a5a2-37bbe608c272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-607958b7-8924-48c9-a5a2-37bbe608c272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

